### PR TITLE
fix(TileContainer): move key prop to anchor element

### DIFF
--- a/frontend/src/components/TileContainer/TileContainer.tsx
+++ b/frontend/src/components/TileContainer/TileContainer.tsx
@@ -15,15 +15,16 @@ const TileContainer: React.FC<TileContainerProps> = ({ links, visible }) => {
   return (
     <div className={`tile-container ${visible ? 'visible' : ''}`}>
       {links &&
-        Object.entries(links).map(([key, value], index) => (
+        Object.entries(links).map(([linkKey, value]) => (
           <a
-              href={`http://${value.toLowerCase()}.otter-verse.com`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="tile-link"
-            >
-            <div key={index} className="tile">
-              {t(key.toLowerCase())}
+            key={linkKey}
+            href={`http://${value.toLowerCase()}.otter-verse.com`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="tile-link"
+          >
+            <div className="tile">
+              {t(linkKey.toLowerCase())}
             </div>
           </a>
         ))}


### PR DESCRIPTION
Assigning the unique key to the <a> element (the outermost element in the map) resolves the React warning about each child in a list needing a unique key prop.